### PR TITLE
Expand gem list to include Mac

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,8 @@ gem "redis", ">= 4.0.1"
 # gem "bcrypt", "~> 3.1.7"
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem "tzinfo-data", platforms: %i[windows jruby]
+gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+
 
 # Reduces boot times through caching; required in config/boot.rb
 gem "bootsnap", require: false
@@ -46,7 +47,7 @@ gem "bootsnap", require: false
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
-  gem "debug", platforms: %i[mri windows]
+  gem "debug", platforms: [:mri, :mingw, :mswin, :x64_mingw]
   # Static analysis for security vulnerabilities [https://brakemanscanner.org/]
   gem "brakeman", require: false
   gem "bundler-audit", require: false
@@ -92,3 +93,4 @@ gem "kamal"
 # Error tracking
 gem "honeybadger"
 gem "hotwire_combobox"
+


### PR DESCRIPTION
This PR is aimed at enhancing the gem file, specifically the gem "tzinfo-data" an "debug" which was, giving issues when attempting to run "bundle install" on a Mac.

